### PR TITLE
Update (external) namespace names in proto files

### DIFF
--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -2,7 +2,7 @@
  * The main API is `DeployService`.
  */
 syntax = "proto3";
-package deploy;
+package casper;
 
 // If you are building for other languages "scalapb.proto"
 // can be manually obtained here:

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -2,9 +2,7 @@
  * The main API is `DeployService`.
  */
 syntax = "proto3";
-package coop.rchain.casper.protocol;
-
-import "google/protobuf/empty.proto";
+package deploy;
 
 // If you are building for other languages "scalapb.proto"
 // can be manually obtained here:
@@ -13,7 +11,8 @@ import "google/protobuf/empty.proto";
 
 import "scalapb/scalapb.proto";
 import "RhoTypes.proto";
-import "Either.proto";
+
+option java_package = "coop.rchain.casper.protocol";
 
 option (scalapb.options) = {
   package_name: "coop.rchain.casper.protocol"

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -12,8 +12,6 @@ package deploy;
 import "scalapb/scalapb.proto";
 import "RhoTypes.proto";
 
-option java_package = "coop.rchain.casper.protocol";
-
 option (scalapb.options) = {
   package_name: "coop.rchain.casper.protocol"
   flat_package: true

--- a/models/src/main/protobuf/DeployService.proto
+++ b/models/src/main/protobuf/DeployService.proto
@@ -15,8 +15,6 @@ import "DeployServiceCommon.proto";
 import "scalapb/scalapb.proto";
 import "Either.proto";
 
-option java_package = "coop.rchain.casper.protocol";
-
 option (scalapb.options) = {
   package_name: "coop.rchain.casper.protocol"
   flat_package: true

--- a/models/src/main/protobuf/DeployService.proto
+++ b/models/src/main/protobuf/DeployService.proto
@@ -2,11 +2,10 @@
  * The main API is `DeployService`.
  */
 syntax = "proto3";
-package coop.rchain.casper.protocol;
+package deploy.v1;
 
 import "CasperMessage.proto";
 import "DeployServiceCommon.proto";
-import "google/protobuf/empty.proto";
 
 // If you are building for other languages "scalapb.proto"
 // can be manually obtained here:
@@ -14,8 +13,9 @@ import "google/protobuf/empty.proto";
 // make a scalapb directory in this file's location and place it inside
 
 import "scalapb/scalapb.proto";
-import "RhoTypes.proto";
 import "Either.proto";
+
+option java_package = "coop.rchain.casper.protocol";
 
 option (scalapb.options) = {
   package_name: "coop.rchain.casper.protocol"

--- a/models/src/main/protobuf/DeployService.proto
+++ b/models/src/main/protobuf/DeployService.proto
@@ -2,7 +2,7 @@
  * The main API is `DeployService`.
  */
 syntax = "proto3";
-package deploy.v1;
+package casper.v1;
 
 import "CasperMessage.proto";
 import "DeployServiceCommon.proto";

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -15,9 +15,8 @@ import "google/protobuf/empty.proto";
 import "scalapb/scalapb.proto";
 import "RhoTypes.proto";
 
-option java_package = "coop.rchain.casper.protocol";
-
 option (scalapb.options) = {
+  package_name: "coop.rchain.casper.protocol"
   flat_package: true
   single_file: true
 };

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -2,7 +2,7 @@
  * The main API is `DeployService`.
  */
 syntax = "proto3";
-package deploy;
+package casper;
 
 import "CasperMessage.proto";
 import "google/protobuf/empty.proto";

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -2,7 +2,7 @@
  * The main API is `DeployService`.
  */
 syntax = "proto3";
-package coop.rchain.casper.protocol;
+package deploy;
 
 import "CasperMessage.proto";
 import "google/protobuf/empty.proto";
@@ -14,6 +14,8 @@ import "google/protobuf/empty.proto";
 
 import "scalapb/scalapb.proto";
 import "RhoTypes.proto";
+
+option java_package = "coop.rchain.casper.protocol";
 
 option (scalapb.options) = {
   flat_package: true

--- a/models/src/main/protobuf/DeployServiceV2.proto
+++ b/models/src/main/protobuf/DeployServiceV2.proto
@@ -15,9 +15,8 @@ import "DeployServiceCommon.proto";
 
 import "scalapb/scalapb.proto";
 
-option java_package = "coop.rchain.casper.protocol.deployV2";
-
 option (scalapb.options) = {
+  package_name: "coop.rchain.casper.protocol.deployV2"
   flat_package: true
   single_file: true
 };

--- a/models/src/main/protobuf/DeployServiceV2.proto
+++ b/models/src/main/protobuf/DeployServiceV2.proto
@@ -2,7 +2,7 @@
  * The main API is `DeployService`.
  */
 syntax = "proto3";
-package deploy.v2;
+package casper.v2;
 
 import "CasperMessage.proto";
 import "ServiceError.proto";

--- a/models/src/main/protobuf/DeployServiceV2.proto
+++ b/models/src/main/protobuf/DeployServiceV2.proto
@@ -2,7 +2,7 @@
  * The main API is `DeployService`.
  */
 syntax = "proto3";
-package coop.rchain.casper.protocol.deployV2;
+package deploy.v2;
 
 import "CasperMessage.proto";
 import "ServiceError.proto";
@@ -15,13 +15,15 @@ import "DeployServiceCommon.proto";
 
 import "scalapb/scalapb.proto";
 
+option java_package = "coop.rchain.casper.protocol.deployV2";
+
 option (scalapb.options) = {
   flat_package: true
   single_file: true
 };
 
-// Use `DoDeploy` to queue deployments of Rholang code and then
-// `ProposeService.propose` to make a new block with the results of running them
+// Use `doDeploy` to queue deployments of Rholang code and then
+// `ProposeServiceV2.propose` to make a new block with the results of running them
 // all.
 //
 // To get results back, use `listenForDataAtName`.

--- a/models/src/main/protobuf/DeployServiceV2.proto
+++ b/models/src/main/protobuf/DeployServiceV2.proto
@@ -27,7 +27,7 @@ option (scalapb.options) = {
 // all.
 //
 // To get results back, use `listenForDataAtName`.
-service DeployServiceV2 {
+service DeployService {
   // Queue deployment of Rholang code (or fail to parse).
   rpc doDeploy(DeployData) returns (DeployResponse) {}
   // Get details about a particular block.

--- a/models/src/main/protobuf/Either.proto
+++ b/models/src/main/protobuf/Either.proto
@@ -1,9 +1,16 @@
 syntax = "proto3";
 
+// If you are building for other languages "scalapb.proto"
+// can be manually obtained here:
+// https://raw.githubusercontent.com/scalapb/ScalaPB/master/protobuf/scalapb/scalapb.proto
+// make a scalapb directory in this file's location and place it inside
+
 import "scalapb/scalapb.proto";
 import "google/protobuf/any.proto";
 
-option java_package = "coop.rchain.either";
+option (scalapb.options) = {
+  package_name: "coop.rchain.either"
+};
 
 message EitherAny {
   string type_url = 1;

--- a/models/src/main/protobuf/ProposeService.proto
+++ b/models/src/main/protobuf/ProposeService.proto
@@ -1,11 +1,11 @@
 syntax = "proto3";
-package coop.rchain.casper.protocol;
+package propose.v1;
 
-import "CasperMessage.proto";
-import "google/protobuf/empty.proto";
 import "ProposeServiceCommon.proto";
 import "Either.proto";
 import "scalapb/scalapb.proto";
+
+option java_package = "coop.rchain.casper.protocol";
 
 option (scalapb.options) = {
   package_name: "coop.rchain.casper.protocol"

--- a/models/src/main/protobuf/ProposeService.proto
+++ b/models/src/main/protobuf/ProposeService.proto
@@ -3,9 +3,13 @@ package propose.v1;
 
 import "ProposeServiceCommon.proto";
 import "Either.proto";
-import "scalapb/scalapb.proto";
 
-option java_package = "coop.rchain.casper.protocol";
+// If you are building for other languages "scalapb.proto"
+// can be manually obtained here:
+// https://raw.githubusercontent.com/scalapb/ScalaPB/master/protobuf/scalapb/scalapb.proto
+// make a scalapb directory in this file's location and place it inside
+
+import "scalapb/scalapb.proto";
 
 option (scalapb.options) = {
   package_name: "coop.rchain.casper.protocol"

--- a/models/src/main/protobuf/ProposeService.proto
+++ b/models/src/main/protobuf/ProposeService.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package propose.v1;
+package casper.v1;
 
 import "ProposeServiceCommon.proto";
 import "Either.proto";

--- a/models/src/main/protobuf/ProposeServiceCommon.proto
+++ b/models/src/main/protobuf/ProposeServiceCommon.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package propose;
+package casper;
 
 // If you are building for other languages "scalapb.proto"
 // can be manually obtained here:

--- a/models/src/main/protobuf/ProposeServiceCommon.proto
+++ b/models/src/main/protobuf/ProposeServiceCommon.proto
@@ -1,9 +1,12 @@
 syntax = "proto3";
 package propose;
 
-import "scalapb/scalapb.proto";
+// If you are building for other languages "scalapb.proto"
+// can be manually obtained here:
+// https://raw.githubusercontent.com/scalapb/ScalaPB/master/protobuf/scalapb/scalapb.proto
+// make a scalapb directory in this file's location and place it inside
 
-option java_package = "coop.rchain.casper.protocol";
+import "scalapb/scalapb.proto";
 
 option (scalapb.options) = {
   package_name: "coop.rchain.casper.protocol"

--- a/models/src/main/protobuf/ProposeServiceCommon.proto
+++ b/models/src/main/protobuf/ProposeServiceCommon.proto
@@ -1,7 +1,9 @@
 syntax = "proto3";
-package coop.rchain.casper.protocol;
+package propose;
 
 import "scalapb/scalapb.proto";
+
+option java_package = "coop.rchain.casper.protocol";
 
 option (scalapb.options) = {
   package_name: "coop.rchain.casper.protocol"

--- a/models/src/main/protobuf/ProposeServiceV2.proto
+++ b/models/src/main/protobuf/ProposeServiceV2.proto
@@ -1,9 +1,11 @@
 syntax = "proto3";
-package coop.rchain.casper.protocol.propose;
+package propose.v2;
 
 import "ServiceError.proto";
 import "ProposeServiceCommon.proto";
 import "scalapb/scalapb.proto";
+
+option java_package = "coop.rchain.casper.protocol.propose";
 
 option (scalapb.options) = {
   flat_package: true

--- a/models/src/main/protobuf/ProposeServiceV2.proto
+++ b/models/src/main/protobuf/ProposeServiceV2.proto
@@ -3,11 +3,16 @@ package propose.v2;
 
 import "ServiceError.proto";
 import "ProposeServiceCommon.proto";
+
+// If you are building for other languages "scalapb.proto"
+// can be manually obtained here:
+// https://raw.githubusercontent.com/scalapb/ScalaPB/master/protobuf/scalapb/scalapb.proto
+// make a scalapb directory in this file's location and place it inside
+
 import "scalapb/scalapb.proto";
 
-option java_package = "coop.rchain.casper.protocol.propose";
-
 option (scalapb.options) = {
+  package_name: "coop.rchain.casper.protocol.propose"
   flat_package: true
   single_file: true
 };

--- a/models/src/main/protobuf/ProposeServiceV2.proto
+++ b/models/src/main/protobuf/ProposeServiceV2.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package propose.v2;
+package casper.v2;
 
 import "ServiceError.proto";
 import "ProposeServiceCommon.proto";

--- a/models/src/main/protobuf/ProposeServiceV2.proto
+++ b/models/src/main/protobuf/ProposeServiceV2.proto
@@ -12,7 +12,7 @@ option (scalapb.options) = {
   single_file: true
 };
 
-service ProposeServiceV2 {
+service ProposeService {
   rpc propose(PrintUnmatchedSendsQuery) returns (ProposeResponse) {}
 }
 

--- a/models/src/main/protobuf/RhoTypes.proto
+++ b/models/src/main/protobuf/RhoTypes.proto
@@ -5,12 +5,15 @@
  */
 syntax = "proto3";
 
-// See CapserMessage.proto if this is causing problems
+// If you are building for other languages "scalapb.proto"
+// can be manually obtained here:
+// https://raw.githubusercontent.com/scalapb/ScalaPB/master/protobuf/scalapb/scalapb.proto
+// make a scalapb directory in this file's location and place it inside
+
 import "scalapb/scalapb.proto";
 
-option java_package = "coop.rchain.models";
-
 option (scalapb.options) = {
+  package_name: "coop.rchain.models"
   import: "coop.rchain.models.BitSetBytesMapper.bitSetBytesMapper"
   import: "coop.rchain.models.ParSetTypeMapper.parSetESetTypeMapper"
   import: "coop.rchain.models.ParMapTypeMapper.parMapEMapTypeMapper"

--- a/models/src/main/protobuf/ServiceError.proto
+++ b/models/src/main/protobuf/ServiceError.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package coop.rchain.casper.protocol;
+option java_package = "coop.rchain.casper.protocol";
 
 message ServiceError {
   repeated string messages = 1;

--- a/models/src/main/protobuf/ServiceError.proto
+++ b/models/src/main/protobuf/ServiceError.proto
@@ -1,5 +1,15 @@
 syntax = "proto3";
-option java_package = "coop.rchain.casper.protocol";
+
+// If you are building for other languages "scalapb.proto"
+// can be manually obtained here:
+// https://raw.githubusercontent.com/scalapb/ScalaPB/master/protobuf/scalapb/scalapb.proto
+// make a scalapb directory in this file's location and place it inside
+
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+  package_name: "coop.rchain.casper.protocol"
+};
 
 message ServiceError {
   repeated string messages = 1;

--- a/models/src/main/protobuf/routing.proto
+++ b/models/src/main/protobuf/routing.proto
@@ -1,10 +1,13 @@
 syntax = "proto3";
 package routing;
 
+// If you are building for other languages "scalapb.proto"
+// can be manually obtained here:
+// https://raw.githubusercontent.com/scalapb/ScalaPB/master/protobuf/scalapb/scalapb.proto
+// make a scalapb directory in this file's location and place it inside
+
 import "scalapb/scalapb.proto";
 import "CasperMessage.proto";
-
-option java_package = "coop.rchain.comm.protocol.routing";
 
 option (scalapb.options) = {
   package_name: "coop.rchain.comm.protocol.routing"

--- a/models/src/main/protobuf/routing.proto
+++ b/models/src/main/protobuf/routing.proto
@@ -1,8 +1,10 @@
 syntax = "proto3";
-package coop.rchain.comm.protocol.routing;
+package routing;
 
 import "scalapb/scalapb.proto";
 import "CasperMessage.proto";
+
+option java_package = "coop.rchain.comm.protocol.routing";
 
 option (scalapb.options) = {
   package_name: "coop.rchain.comm.protocol.routing"

--- a/node/src/main/protobuf/repl.proto
+++ b/node/src/main/protobuf/repl.proto
@@ -1,7 +1,16 @@
 syntax = "proto3";
 package repl;
 
-option java_package = "coop.rchain.node.model";
+// If you are building for other languages "scalapb.proto"
+// can be manually obtained here:
+// https://raw.githubusercontent.com/scalapb/ScalaPB/master/protobuf/scalapb/scalapb.proto
+// make a scalapb directory in this file's location and place it inside
+
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+  package_name: "coop.rchain.node.model"
+};
 
 service Repl {
   rpc Run (CmdRequest) returns (ReplResponse) {}

--- a/node/src/main/protobuf/repl.proto
+++ b/node/src/main/protobuf/repl.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
+package repl;
 
-package coop.rchain.node.model;
+option java_package = "coop.rchain.node.model";
 
 service Repl {
   rpc Run (CmdRequest) returns (ReplResponse) {}

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -759,9 +759,9 @@ object NodeRuntime {
   final case class APIServers(
       repl: ReplGrpcMonix.Repl,
       propose: ProposeServiceGrpcMonix.ProposeService,
-      proposeV2: ProposeServiceV2GrpcMonix.ProposeServiceV2,
+      proposeV2: ProposeServiceV2GrpcMonix.ProposeService,
       deploy: DeployServiceGrpcMonix.DeployService,
-      deployV2: DeployServiceV2GrpcMonix.DeployServiceV2
+      deployV2: DeployServiceV2GrpcMonix.DeployService
   )
 
   def acquireAPIServers[F[_]](

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV2.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV2.scala
@@ -40,8 +40,8 @@ object DeployGrpcServiceV2 {
       blockApiLock: Semaphore[F]
   )(
       implicit worker: Scheduler
-  ): DeployServiceV2GrpcMonix.DeployServiceV2 =
-    new DeployServiceV2GrpcMonix.DeployServiceV2 {
+  ): DeployServiceV2GrpcMonix.DeployService =
+    new DeployServiceV2GrpcMonix.DeployService {
 
       private def defer[A, R <: StacksafeMessage[R]](
           task: F[Either[String, A]]

--- a/node/src/main/scala/coop/rchain/node/api/ProposeGrpcServiceV2.scala
+++ b/node/src/main/scala/coop/rchain/node/api/ProposeGrpcServiceV2.scala
@@ -27,8 +27,8 @@ object ProposeGrpcServiceV2 {
       blockApiLock: Semaphore[F]
   )(
       implicit worker: Scheduler
-  ): ProposeServiceV2GrpcMonix.ProposeServiceV2 =
-    new ProposeServiceV2GrpcMonix.ProposeServiceV2 {
+  ): ProposeServiceV2GrpcMonix.ProposeService =
+    new ProposeServiceV2GrpcMonix.ProposeService {
 
       private def defer[A, R <: StacksafeMessage[R]](
           task: F[Either[String, A]]

--- a/node/src/main/scala/coop/rchain/node/api/package.scala
+++ b/node/src/main/scala/coop/rchain/node/api/package.scala
@@ -26,7 +26,7 @@ package object api {
       grpcExecutor: Scheduler,
       replGrpcService: ReplGrpcMonix.Repl,
       proposeGrpcService: ProposeServiceGrpcMonix.ProposeService,
-      proposeGrpcServiceV2: ProposeServiceV2GrpcMonix.ProposeServiceV2
+      proposeGrpcServiceV2: ProposeServiceV2GrpcMonix.ProposeService
   ): Task[Server[Task]] =
     GrpcServer[Task](
       NettyServerBuilder
@@ -52,9 +52,9 @@ package object api {
       port: Int,
       grpcExecutor: Scheduler,
       deployGrpcService: DeployServiceGrpcMonix.DeployService,
-      deployGrpcServiceV2: DeployServiceV2GrpcMonix.DeployServiceV2,
+      deployGrpcServiceV2: DeployServiceV2GrpcMonix.DeployService,
       proposeGrpcService: ProposeServiceGrpcMonix.ProposeService,
-      proposeGrpcServiceV2: ProposeServiceV2GrpcMonix.ProposeServiceV2
+      proposeGrpcServiceV2: ProposeServiceV2GrpcMonix.ProposeService
   ): F[Server[F]] =
     GrpcServer[F](
       NettyServerBuilder


### PR DESCRIPTION
It would be useful to use shorter names for namespaces in proto definitions. Scala generated code will still be the same as now, only the client interpretation is changed.
But the main motivation is to distinguish between service versions so client generators can filter out types related to specific versions. Here is an example in [rnode-grpc-js](https://github.com/tgrospic/rnode-grpc-js/commit/9a2fe3cb2d9e2ca0bece5827a1ac56b88bc7d3c8) how this is used to filter and generate TypeScript definitions for V1 and V2.

Another change is to have the same service names for all versions. With both of the changes client migration from version to version can be done less painfully.